### PR TITLE
fix: queryStatus types

### DIFF
--- a/src/ReactQuery_Types.res
+++ b/src/ReactQuery_Types.res
@@ -25,7 +25,7 @@ type infiniteData<'queryData> = {
   pageParams: array<int>,
 }
 
-type queryStatus = [#loading | #success | #error | #initialData]
+type queryStatus = [#pending | #success | #error]
 
 type placeholderData<'queryData, 'queryResult> = [
   | #data('queryData)


### PR DESCRIPTION
- [x] Fixes wrong queryStatus types as in v5
- [x] Changed types of queryStatus from  `type queryStatus = [#loading | #success | #error | #initialData]` to `type queryStatus = [#pending | #success | #error]`